### PR TITLE
Korjausehdotus värikoodeihin ja sanan vaihtaminen

### DIFF
--- a/app.js
+++ b/app.js
@@ -246,7 +246,7 @@ function checkIfValid(target) {
         break;
 
     case 'queen':
-        // Lisää logiikka kuninkaan siirroille
+        // Lisää logiikka kuningattaren siirroille
         if (
             startId + width + 1 === targetId ||
             startId + width * 2 + 2 === targetId && !document.querySelector(`[square-id="${startId + width + 1}"]`)?.firstChild ||

--- a/styles.css
+++ b/styles.css
@@ -31,15 +31,18 @@ path {
 }
 
 .beige {
-    background-color: beige;
+    /* background-color: beige; */
+    background-color: rgb(240,217,181);
 }
 
 .brown {
-    background-color: rgb(111, 1, 1);
+    /* background-color: rgb(111, 1, 1); */
+    background-color: rgb(181, 136, 99);
 }
 
 .black {
-    fill: rgb(108, 0, 0);
+    /* fill: rgb(108, 0, 0); */
+    fill: rgb(0, 0, 0);
 }
 
 .white {


### PR DESCRIPTION
Korjasin riviltä 249 sanan kuningas kuningattareksi. Ehdotan css-koodissa pelilaudan ruutuihin ja mustien nappuloiden värikoodeihin muutoksia kontrastin parantamiseksi. Aikaisemmilla värikoodeilla mustat nappulat hävisivät pelilaudan tummiin ruutuihin ja valkoiset nappulat näkyivät himmeinä vaaleissa ruuduissa. Selaimen vaihto Safarista Chromeen ei auttanut.